### PR TITLE
Add sun50i-a64-i2c2 for activating TWI2 I2C

### DIFF
--- a/sun50i-a64/sun50i-a64-i2c2.dts
+++ b/sun50i-a64/sun50i-a64-i2c2.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun50i-a64",
+		     "olimex,a64-olinuxino";
+	description = "Enable TWI2 bus";
+
+	fragment@0 {
+		target = <&i2c2>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
TWI2 is very convenient to use as an alternative to TWI1 exposed at the UEXT port.

TWI0 is not convenient as it is exposed in a MiPi-DSI display connector pointing towards the side of the A64-Olinuxino boards, so impossible to use if you have it inside the "metal box for A64-Olinuxino".

TWI2 is exposed in the GPIO1 port at pins 33 (PE14 in the CPU, function SCL) and 35 (PE15 in the CPU, function SDA).
