### PR TITLE
Added 1-wire DTS for A64 on PE12

### DIFF
--- a/sun50i-a64/sun50i-a64-w1-gpio.dts
+++ b/sun50i-a64/sun50i-a64-w1-gpio.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun50i-a64",
+                     "olimex,a64-olinuxino";
+	description = "Enable 1-Wire port (on PE12: pin 29 of GPIO1)";
+
+	fragment@0 {
+		target-path="/";
+		__overlay__ {
+			onewire {
+				compatible = "w1-gpio";
+				gpios = <&pio 4 12 16>;
+				/* 4: E of PE12
+				12: 12 of PE12
+				16: GPIO_PULL_UP as defined in dt-bindings/gpio/gpio.h */
+				status = "okay";
+			};
+		};
+	};
+};


### PR DESCRIPTION
See https://www.olimex.com/forum/index.php?topic=9266.0
and see https://groups.google.com/g/linux-sunxi/c/kxhjj3undlk

This configures PE12 pin (pin 140 from the CPU point of view, exposed as pin 29 in the GPIO1 port of the A64-olinuxino) for usage with a 1-wire device.

From my testing with DS18B20, an external pull up resistor is needed, the thermometer has to be powered with an external power supply and the 5V pin of the GPIO1 port has to be connected to the 5V of the external power supply.

In the picture, the data line is connected to PB0 (exposed as pin 10 in GPIO1 port), but the current version of the code activates the 1-wire on PE12, which is not used for anything else.

![](https://uz.sns.it/~ilario/20231030-1wire-A64-hardware_connections.jpg)

See more details on https://groups.google.com/g/linux-sunxi/c/kxhjj3undlk

